### PR TITLE
Seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,17 @@ beneficiosa para nuestra comunidad basada en la programación funcional, como po
 realización de workshops, hackathons, o lo que se os ocurra. 
 
 Sin importar sexo, edad, origen o condición.
-¡Anímate *ahora*!
+
+**¡Anímate!**
 
 > In [FunctionalJS] (https://www.meetup.com/es-ES/functionalFP/)
 We are actively looking for talks on functional programming that are related to
-Javascript.
-
-> In addition to the talks we are also open to any other type of collaboration that may be
+Javascript.<br><br>
+In addition to the talks we are also open to any other type of collaboration that may be
 beneficial to our community based on functional programming, such as
 conducting workshops, hackathons, or whatever you can think of.
-
-> Regardless of sex, age, origin or condition.
-C'mon be part of us *now* !
+<br>Regardless of sex, age, origin or condition.
+<br>C'mon be part of us **now** !
 
 ## Envíanos tu propuesta  / Send us your proposal
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ conducting workshops, hackathons, or whatever you can think of.
 <br><br>C'mon be part of us **now** !
 
 ## Envíanos tu propuesta  / Send us your proposal
-
-Envía un [_issue_](https://github.com/functionalprogrammingjs/talks-and-more/issues/new) para 
+Envía un [_issue_](https://github.com/functionalprogrammingjs/talks-and-more/issues/new/choose) 
+para 
 proponer un evento. Por favor, incluye:
 
 * **Título** de la charla.
@@ -44,7 +44,7 @@ proponer un evento. Por favor, incluye:
 Contactaremos contigo para confirmar recepción, y buscar la fecha idonea para la charla.
 
 
->Send an issue (https://github.com/functionalprogrammingjs/talks-and-more/issues/new) 
+>Send an issue (https://github.com/functionalprogrammingjs/talks-and-more/issues/new/choose) 
 to propose a talk. Please include:
 > * **Title** of the talk.
 > * **Description:** a few sentences explaining what you will talk about.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 Este repositorio sirve para organizar las propuestas de nuestros encuentros  de charlas, workshops,
  etc.<br>
 Publicaremos los encuentros en [Meetup.com](https://www.meetup.com/es-ES/functionalFP/).
-
-<font color="blue>This repo is ment to organize propossed talks, workshops etc. for our 
+<pre>
+This repo is ment to organize propossed talks, workshops etc. for our 
 mettups<br>
-We will publish our meetups in [Meetup.com](https://www.meetup.com/es-ES/functionalFP/).</font>
+We will publish our meetups in [Meetup.com](https://www.meetup.com/es-ES/functionalFP/)
+</pre>
 
 
 ## Propuestas

--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ Publicaremos los encuentros en [Meetup.com](https://www.meetup.com/es-ES/functio
 ### Aquí encontrarás el [listado de las charlas pasadas y venideras](./talks.md) 
 
 > This repo is meant to organize proposed talks, workshops etc. for our meetings<br>
-We will publish our meetups in [Meetup.com](https://www.meetup.com/es-ES/functionalFP/) <br><br>
+We will publish our meetups in [Meetup.com](https://www.meetup.com/es-ES/functionalFP/) <br>
 ### Here you will find [the list of new and old talks ](./talks.md) 
 
+<hr>
 
-## Propuestas / Proposses
+# Propuestas / Proposses
 
 En [FunctionalJS](https://www.meetup.com/es-ES/functionalFP/)
 estamos buscando activamente charlas sobre programación funcional y que tengan relación con 
@@ -55,8 +56,9 @@ to propose a talk. Please include:
 > * **Constraints:** we always try to suit your needs.
 ><br>We will contact you to confirm reception, and find the ideal date for the talk.
 
+<hr>
 
-## Código de conducta / Code of Conduct
+# Código de conducta / Code of Conduct
 Para asegurarnos el buen rollo y el correctofuncionamiento de este meetup, 
 hemos creado un código que lo podes leer aquí [código de conducta](code-of-conduct-es.md) 
 Si creeis que este código de conducta se puede mejorar por favor no duesi en enviarnos vuestras

--- a/README.md
+++ b/README.md
@@ -75,3 +75,10 @@ aportaciones haciendo PR sobre los archivos:
 
 [code of conduct SPANISH](code-of-conduct-es.md)<br>
 [code of conduct ENGLISH](code-of-conduct-en.md)
+
+
+## Contacto (mantenedores)  / Contact (maintainers)
+
+ * [Maurice Domínguez](mailto:maurice.ronet.dominguez@gmail.com)
+ * [Miguel Martín](mailto:miguel@redradix.com)
+ * [Rodrigo Erades](mailto:rerades@siete3.com)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
-# Talks & more
+# Functional Programming <Talks & more>
+
+Este repositorio sirve para organizar las propuestas de nuestros encuentros  de charlas, workshops,
+ etc.<br>
+Publicaremos los encuentros en [Meetup.com](https://www.meetup.com/es-ES/functionalFP/).
+<pre>
+<font color="blue>This repo is ment to organize propossed talks, workshops etc. for our 
+mettups<br>
+We will publish our meetups in [Meetup.com](https://www.meetup.com/es-ES/functionalFP/).</font>
+</pre>
+
+## Propuestas
+
+En [MadridJS](http://www.meetup.com/madridjs/)
+estamos buscando activamente charlas sobre JavaScript,
+de unos 40 minutos de duración.
+Sin importar sexo, edad, origen o condición.
+¡Anímate *ahora*!
+
+Envía un [_issue_](https://github.com/MadridJs/talks/issues/new) para proponer una charla. Por favor, incluye:
+
+* Título de la charla.
+* Descripción: unas cuantas frases sobre lo que quieres hablar.
+* Bio de ponente: ¿quién eres, y qué haces en tu tiempo libre?
+* Condicionantes: siempre intentaremos amoldarnos a tus necesidades.
+
+Contactaremos contigo para confirmar recepción, y para asignarte fecha tentativa.
+Te avisaremos ya en firme con varias semanas de antelación.
+
+## Call for Proposals
+
+At [MadridJS](http://www.meetup.com/madridjs/)
+we are actively seeking talks about JavaScript,
+about 40 minutes long.
+No matter gender, age, origin or condition.
+Send yours *now*!
+
+Send an [issue](https://github.com/MadridJs/talks/issues/new) to propose a talk. Please include:
+
+* Title of the talk.
+* Description: a few sentences explaining what you will talk about.
+* Bio: who are you, and what do you do?
+* Constraints: we always try to suit your needs.
+
+We will contact you to confirm reception, and to assign tentative date.
+We will then notify you with a final date, several weeks in advance.
+
+## Código de conducta
+
+Para asegurarnos que seamos todos tan majos con los demás como hasta ahora,
+hemos elaborado este [código de conducta](codigo-conducta.md) donde viene por escrito.
+Es nuestro compromiso con un ambiente libre de malos rollos.
+
+## Code of Conduct
+
+To ensure that we are all as nice to each other as we have been so far,
+we have adopted this [code of conduct](codigo-conducta.md), right now in Spanish only,
+but you can read our [inspiring](http://www.meetup.com/pdxpython/pages/Code_of_Conduct/)
+[policies](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).
+In a nutshell: don't be a jerk to others.
+Contact [Alex Fernández](mailto:alexfernandeznpm@gmail.com) if you have any doubts.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ Este repositorio sirve para organizar las propuestas de nuestros encuentros  de 
  etc.<br>
 Publicaremos los encuentros en [Meetup.com](https://www.meetup.com/es-ES/functionalFP/).
 
+### Aquí encontrarás el [listado de las charlas pasadas y venideras](./talks.md) 
+
 > This repo is meant to organize proposed talks, workshops etc. for our meetings<br>
-We will publish our meetups in [Meetup.com](https://www.meetup.com/es-ES/functionalFP/)
+We will publish our meetups in [Meetup.com](https://www.meetup.com/es-ES/functionalFP/) <br><br>
+### Here you will find [the list of new and old talks ](./talks.md) 
 
 
 ## Propuestas / Proposses

--- a/README.md
+++ b/README.md
@@ -3,8 +3,12 @@
 Este repositorio sirve para organizar las propuestas de nuestros encuentros  de charlas, workshops,
  etc.<br>
 Publicaremos los encuentros en [Meetup.com](https://www.meetup.com/es-ES/functionalFP/).
+
+
+<span color="red">This repo</span> is <span style="color:red">ment</span>
+
 <pre>
-This repo is ment to organize propossed talks, workshops etc. for our 
+<span color="red">This repo</span> is <span style="color:red">ment</span> to organize propossed talks, workshops etc. for our 
 mettups<br>
 We will publish our meetups in [Meetup.com](https://www.meetup.com/es-ES/functionalFP/)
 </pre>

--- a/README.md
+++ b/README.md
@@ -54,17 +54,18 @@ to propose a talk. Please include:
 
 
 ## Código de conducta / Code of Conduct
+Para asegurarnos el buen rollo y el correctofuncionamiento de este meetup, 
+hemos creado un código que lo podes leer aquí [código de conducta](code-of-conduct-es.md) 
+Si creeis que este código de conducta se puede mejorar por favor no duesi en enviarnos vuestras
+aportaciones haciendo PR sobre los archivos:
 
+[código de conducta ESPAÑOL](code-of-conduct-es.md)
+[código de conducta INGLES](code-of-conduct-en.md)
 
-Para asegurarnos que seamos todos tan majos con los demás como hasta ahora,
-hemos elaborado este [código de conducta](codigo-conducta.md) donde viene por escrito.
-Es nuestro compromiso con un ambiente libre de malos rollos.
+>To ensure the good vibes and the correct functioning of this meetup,
+ we have created a code of conduct that you can read here [code of conduct] (code-of-conduct-en.md)
+ If you believe that this code of conduct can be improved please do not hesitate to send us your
+ contributions making a PR on these files:
 
-## Code of Conduct
-
-To ensure that we are all as nice to each other as we have been so far,
-we have adopted this [code of conduct](codigo-conducta.md), right now in Spanish only,
-but you can read our [inspiring](http://www.meetup.com/pdxpython/pages/Code_of_Conduct/)
-[policies](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).
-In a nutshell: don't be a jerk to others.
-Contact [Alex Fernández](mailto:alexfernandeznpm@gmail.com) if you have any doubts.
+[código de conducta SPANISH](code-of-conduct-es.md)
+[código de conducta ENGLISH](code-of-conduct-en.md)

--- a/README.md
+++ b/README.md
@@ -5,13 +5,9 @@ Este repositorio sirve para organizar las propuestas de nuestros encuentros  de 
 Publicaremos los encuentros en [Meetup.com](https://www.meetup.com/es-ES/functionalFP/).
 
 
-<span color="red">This repo</span> is <span style="color:red">ment</span>
-
-<pre>
-<span color="red">This repo</span> is <span style="color:red">ment</span> to organize propossed talks, workshops etc. for our 
-mettups<br>
+> This repo is ment to organize propossed talks, workshops etc. for our mettups<br>
 We will publish our meetups in [Meetup.com](https://www.meetup.com/es-ES/functionalFP/)
-</pre>
+
 
 
 ## Propuestas

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 Este repositorio sirve para organizar las propuestas de nuestros encuentros  de charlas, workshops,
  etc.<br>
 Publicaremos los encuentros en [Meetup.com](https://www.meetup.com/es-ES/functionalFP/).
-<pre>
+
 <font color="blue>This repo is ment to organize propossed talks, workshops etc. for our 
 mettups<br>
 We will publish our meetups in [Meetup.com](https://www.meetup.com/es-ES/functionalFP/).</font>
-</pre>
+
 
 ## Propuestas
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ hemos creado un código que lo podes leer aquí [código de conducta](code-of-co
 Si creeis que este código de conducta se puede mejorar por favor no duesi en enviarnos vuestras
 aportaciones haciendo PR sobre los archivos:
 
-[código de conducta ESPAÑOL](code-of-conduct-es.md)
+[código de conducta ESPAÑOL](code-of-conduct-es.md) <br>
 [código de conducta INGLES](code-of-conduct-en.md)
 
 >To ensure the good vibes and the correct functioning of this meetup,
@@ -67,5 +67,5 @@ aportaciones haciendo PR sobre los archivos:
  If you believe that this code of conduct can be improved please do not hesitate to send us your
  contributions making a PR on these files:
 
-[código de conducta SPANISH](code-of-conduct-es.md)
+[código de conducta SPANISH](code-of-conduct-es.md)<br>
 [código de conducta ENGLISH](code-of-conduct-en.md)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Sin importar sexo, edad, origen o condición.
 
 **¡Anímate!**
 
-> In [FunctionalJS] (https://www.meetup.com/es-ES/functionalFP/)
+> In FunctionalJS (https://www.meetup.com/es-ES/functionalFP/)
 We are actively looking for talks on functional programming that are related to
 Javascript.<br><br>
 In addition to the talks we are also open to any other type of collaboration that may be
@@ -44,7 +44,7 @@ proponer un evento. Por favor, incluye:
 Contactaremos contigo para confirmar recepción, y buscar la fecha idonea para la charla.
 
 
->Send an [issue](https://github.com/functionalprogrammingjs/talks-and-more/issues/new) 
+>Send an issue (https://github.com/functionalprogrammingjs/talks-and-more/issues/new) 
 to propose a talk. Please include:
 > * **Title** of the talk.
 > * **Description:** a few sentences explaining what you will talk about.
@@ -63,9 +63,10 @@ aportaciones haciendo PR sobre los archivos:
 [código de conducta INGLES](code-of-conduct-en.md)
 
 >To ensure the good vibes and the correct functioning of this meetup,
- we have created a code of conduct that you can read here [code of conduct] (code-of-conduct-en.md)
+ we have created a code of conduct that you can read here (./code-of-conduct-en
+ .md)
  If you believe that this code of conduct can be improved please do not hesitate to send us your
  contributions making a PR on these files:
 
-[código de conducta SPANISH](code-of-conduct-es.md)<br>
-[código de conducta ENGLISH](code-of-conduct-en.md)
+[code of conduct SPANISH](code-of-conduct-es.md)<br>
+[code of conduct ENGLISH](code-of-conduct-en.md)

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ proponer un evento. Por favor, incluye:
 
 Contactaremos contigo para confirmar recepción, y buscar la fecha idonea para la charla.
 
+
 >Send an [issue](https://github.com/functionalprogrammingjs/talks-and-more/issues/new) 
 to propose a talk. Please include:
 > * Title of the talk.
 > * Description: a few sentences explaining what you will talk about.
 > * Bio: who are you, and what do you do?
 > * Constraints: we always try to suit your needs.
-
->We will contact you to confirm reception, and find the ideal date for the talk.
+><br>We will contact you to confirm reception, and find the ideal date for the talk.
 
 
 ## Código de conducta / Code of Conduct

--- a/README.md
+++ b/README.md
@@ -29,27 +29,27 @@ In addition to the talks we are also open to any other type of collaboration tha
 beneficial to our community based on functional programming, such as
 conducting workshops, hackathons, or whatever you can think of.
 <br>Regardless of sex, age, origin or condition.
-<br>C'mon be part of us **now** !
+<br><br>C'mon be part of us **now** !
 
 ## Envíanos tu propuesta  / Send us your proposal
 
 Envía un [_issue_](https://github.com/functionalprogrammingjs/talks-and-more/issues/new) para 
 proponer un evento. Por favor, incluye:
 
-* Título de la charla.
-* Descripción: unas cuantas frases sobre lo que quieres hablar.
-* Bio de ponente: ¿quién eres, y qué haces en tu tiempo libre?
-* Condicionantes: siempre intentaremos amoldarnos a tus necesidades.
+* **Título** de la charla.
+* **Descripción:** unas cuantas frases sobre lo que quieres hablar.
+* **Bio de ponente:** ¿quién eres, y qué haces en tu tiempo libre?
+* **Condicionantes:** siempre intentaremos amoldarnos a tus necesidades.
 
 Contactaremos contigo para confirmar recepción, y buscar la fecha idonea para la charla.
 
 
 >Send an [issue](https://github.com/functionalprogrammingjs/talks-and-more/issues/new) 
 to propose a talk. Please include:
-> * Title of the talk.
-> * Description: a few sentences explaining what you will talk about.
-> * Bio: who are you, and what do you do?
-> * Constraints: we always try to suit your needs.
+> * **Title** of the talk.
+> * **Description:** a few sentences explaining what you will talk about.
+> * **Bio:** who are you, and what do you do?
+> * **Constraints:** we always try to suit your needs.
 ><br>We will contact you to confirm reception, and find the ideal date for the talk.
 
 

--- a/README.md
+++ b/README.md
@@ -1,52 +1,61 @@
-# Functional Programming <Talks & more>
+# Talks & more 
 
 Este repositorio sirve para organizar las propuestas de nuestros encuentros  de charlas, workshops,
  etc.<br>
 Publicaremos los encuentros en [Meetup.com](https://www.meetup.com/es-ES/functionalFP/).
 
-
-> This repo is ment to organize propossed talks, workshops etc. for our mettups<br>
+> This repo is meant to organize proposed talks, workshops etc. for our meetings<br>
 We will publish our meetups in [Meetup.com](https://www.meetup.com/es-ES/functionalFP/)
 
 
+## Propuestas / Proposses
 
-## Propuestas
+En [FunctionalJS](https://www.meetup.com/es-ES/functionalFP/)
+estamos buscando activamente charlas sobre programación funcional y que tengan relación con 
+Javascript.
 
-En [MadridJS](http://www.meetup.com/madridjs/)
-estamos buscando activamente charlas sobre JavaScript,
-de unos 40 minutos de duración.
+Además de las charlas también estamos abiertos a cualquier otro tipo de colaboración que pueda ser
+beneficiosa para nuestra comunidad basada en la programación funcional, como podría ser la 
+realización de workshops, hackathons, o lo que se os ocurra. 
+
 Sin importar sexo, edad, origen o condición.
 ¡Anímate *ahora*!
 
-Envía un [_issue_](https://github.com/MadridJs/talks/issues/new) para proponer una charla. Por favor, incluye:
+> In [FunctionalJS] (https://www.meetup.com/es-ES/functionalFP/)
+We are actively looking for talks on functional programming that are related to
+Javascript.
+
+> In addition to the talks we are also open to any other type of collaboration that may be
+beneficial to our community based on functional programming, such as
+conducting workshops, hackathons, or whatever you can think of.
+
+> Regardless of sex, age, origin or condition.
+C'mon be part of us *now* !
+
+## Envíanos tu propuesta  / Send us your proposal
+
+Envía un [_issue_](https://github.com/functionalprogrammingjs/talks-and-more/issues/new) para 
+proponer un evento. Por favor, incluye:
 
 * Título de la charla.
 * Descripción: unas cuantas frases sobre lo que quieres hablar.
 * Bio de ponente: ¿quién eres, y qué haces en tu tiempo libre?
 * Condicionantes: siempre intentaremos amoldarnos a tus necesidades.
 
-Contactaremos contigo para confirmar recepción, y para asignarte fecha tentativa.
-Te avisaremos ya en firme con varias semanas de antelación.
+Contactaremos contigo para confirmar recepción, y buscar la fecha idonea para la charla.
 
-## Call for Proposals
+>Send an [issue](https://github.com/functionalprogrammingjs/talks-and-more/issues/new) 
+to propose a talk. Please include:
+> * Title of the talk.
+> * Description: a few sentences explaining what you will talk about.
+> * Bio: who are you, and what do you do?
+> * Constraints: we always try to suit your needs.
 
-At [MadridJS](http://www.meetup.com/madridjs/)
-we are actively seeking talks about JavaScript,
-about 40 minutes long.
-No matter gender, age, origin or condition.
-Send yours *now*!
+>We will contact you to confirm reception, and find the ideal date for the talk.
 
-Send an [issue](https://github.com/MadridJs/talks/issues/new) to propose a talk. Please include:
 
-* Title of the talk.
-* Description: a few sentences explaining what you will talk about.
-* Bio: who are you, and what do you do?
-* Constraints: we always try to suit your needs.
+## Código de conducta / Code of Conduct
 
-We will contact you to confirm reception, and to assign tentative date.
-We will then notify you with a final date, several weeks in advance.
-
-## Código de conducta
 
 Para asegurarnos que seamos todos tan majos con los demás como hasta ahora,
 hemos elaborado este [código de conducta](codigo-conducta.md) donde viene por escrito.

--- a/code-of-conduct-en.md
+++ b/code-of-conduct-en.md
@@ -1,0 +1,53 @@
+**NOTE:** From now on every time we use the word "meetup" in this document we are referencing any 
+meeting, 
+talk, event, communication chanel such us tweeter, meeetup.com, facebook, github, or any other channel 
+used to spread the word of this community.
+
+All attendees, speakers, sponsors and volunteers at our "meetup" are required to agree with the 
+following code of conduct. 
+
+Organisers will enforce this code throughout the "meetup". We expect 
+cooperation from all participants to help ensure a safe environment for everybody.
+
+## The Quick Version
+Our "meetup" is a harassment-free place for everyone, regardless of gender, gender identity
+and expression, age, sexual orientation, disability, physical appearance, body size, race, 
+ethnicity, religion (or lack thereof), or technology choices. 
+We do not tolerate harassment of meetup participants in any form. Sexual language and imagery 
+is not appropriate for any meetup venue.
+
+Meetup participants violating these rules may be sanctioned or expelled 
+from the meetup without a refund at the discretion of the meetup organisers.
+
+## The Less Quick Version
+Harassment includes offensive verbal comments related to gender, gender identity and expression,
+age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion,
+technology choices, sexual images in public spaces, deliberate intimidation, stalking, following,
+harassing photography or recording, sustained disruption of talks or other events, inappropriate 
+physical contact, and unwelcome sexual attention.
+
+Participants asked to stop any harassing behavior are expected to comply immediately.
+
+Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use 
+sexualised images, activities, or other material. Booth staff (including volunteers) should not 
+use sexualised clothing/uniforms/costumes, or otherwise create a sexualised environment.
+
+If a participant engages in harassing behavior, the meetup organisers may take any action they 
+deem appropriate, including warning the offender or expulsion from the meetup with no refund.
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, 
+please contact a member of meetup staff immediately.
+
+the organizers will be happy to help the participants who experience harassment to feel
+insurance for the duration of the meeting and to do everything in their power to avoid
+this type of situations.
+We hope that participants follow these rules in all the forums of this meetup
+
+Based on 
+[Web Standards Russia](https://github.com/web-standards-ru/code-of-conduct) ,
+[JSConf 2012 code of conduct](http://2012.jsconf.us/#/about) 
+and [The Ada Initiative](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).
+
+Licensed under a [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/deed.en_US).
+
+

--- a/code-of-conduct-es.md
+++ b/code-of-conduct-es.md
@@ -1,0 +1,57 @@
+
+**NOTA:** De ahora en adelante, cada vez que usemos la palabra "meetup" en este documento nos 
+referimos areunión,charla, evento, canal de comunicación como tweeter, meeetup.com, facebook, github o 
+cualquier otro canal que ​​difunda la palabra de esta comunidad.
+
+Todos los asistentes, oradores, patrocinadores y voluntarios de nuestro meetup deben estar de 
+acuerdo con el Código de conducta siguiente.
+
+Los organizadores aplicarán este código a lo largo del meetup. 
+Esperamos la cooperación de todos los participantes para ayudar a garantizar un entorno seguro 
+para todos.
+
+## La versión rápida
+Nuestro meetup es un lugar libre de acoso para todos, sin importar el género, la identidad de género
+y expresión, edad, orientación sexual, discapacidad, apariencia física, tamaño corporal, raza,
+Etnicidad, religión (o falta de ella), u opciones de tecnología.
+No toleramos el acoso de los participantes en reuniones de ninguna forma. El lenguaje sexual e 
+imagenes no es apropiado en este meetup
+
+Los participantes del meetup que violen estas reglas pueden ser sancionados o expulsados
+sin ningún tipo de contraprestación a discreción de los organizadores del meetup.
+
+## La versión menos rápida
+El acoso incluye comentarios verbales ofensivos relacionados con el género, la identidad de género y
+la expresión, edad, orientación sexual, discapacidad, apariencia física, tamaño corporal, raza, 
+etnia, religión, opciones tecnológicas, imágenes sexuales en espacios públicos, intimidación, 
+acoso, seguimiento, acosar con fotografía o grabaciones, interrupciones continuadas de las 
+charlas u otros eventos, contacto físico inapropiado y atención sexual no deseada.
+
+Se espera que los participantes a los que se les pida que detengan cualquier comportamiento de 
+acoso cumplan de inmediato.
+
+Los patrocinadores también están sujetos a la política contra el acoso. En particular, los 
+patrocinadores no deben usar imágenes, actividades u otro material de contenido sexual.
+El personal del stand o similar (incluidos los voluntarios) no debe use ropa / uniformes / 
+disfraces sexualizados, o cree un ambiente sexualizado.
+
+Si un participante se involucra en un comportamiento de acoso, los organizadores de la reunión 
+pueden tomar cualquier acción que juzgue apropiado, incluyendo advertir al ofensor o expulsión de
+la reunión o grupo sin reembolso.
+
+Si está siendo acosado,  o piensa que alguien más está siendo acosado o tiene alguna otra 
+inquietud, por favor, póngase en contacto con un miembro del meetup inmediatamente.
+
+los organizadores estarán encantados de ayudar a los participantes quienes experimentan acoso a sentirse
+seguros durante el tiempo que dure el encuentro y a hacer todo lo que esté en su mano para evitar
+este tipo de situaciones.
+Esperamos que los participantes sigan estas reglas en todos los foros de este meetup
+
+Basado en 
+[Web Standards Russia](https://github.com/web-standards-ru/code-of-conduct) ,
+[JSConf 2012 code of conduct](http://2012.jsconf.us/#/about) 
+y [The Ada Initiative](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).
+
+Licenciado bajo [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/deed.en_US).
+
+

--- a/talks.md
+++ b/talks.md
@@ -1,0 +1,4 @@
+# TALKS 
+
+## Marzo 2019
+[Programación funcional en el mundo real](https://www.meetup.com/es-ES/functionalFP/events/258497305/)


### PR DESCRIPTION
Hola , os comparto el PR para la sección de Talks & more.

Me he basado en el de MadridJS

He creado también una plantilla para las ISSUES de las charlas.

He creado un talks.md en donde podemos poner el listado de las charlas pasadas y venideras.
En principio os he puesto la primera con el enlace al meetup pero a lo mejor podríamos poner más info que veais relevante (url del repo, comentarios etc).

También he creado el código de conducta en español e ingles. Me he basado en otros que están referenciados al final del documento.

Las nuevas charlas las deberíamos de poder hacer ya con este sistema si os parece bien :) y así tenerlas organizadas.

Creo que faltaría también en el README una parte en donde poner los organizadores / mantenedores del grupo, si me quereis poner a mi por mi encantado :) en poderos ayudar pero os lo dejo a vuestra elección , sin presión ;).


Saludos
